### PR TITLE
feat: devops alanı eklendi

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -3,6 +3,7 @@
     "mobile",
     "backend",
     "frontend",
+    "devops",
     "pm",
     "qa",
     "game",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Zorunlu staj ihtiyacı olan öğrenci arkadaşların kendini tanıtabileceği, p
   **AD-SOYAD [ALAN][STAJ YERİ][STAJ TİPİ][STAJ SÜRESİ]**
   
 - **Alan** kısmı şu bilgilerden birini veya birden fazlasını içerebilir:  
-  `["mobile", "backend", "frontend", "pm", "qa", "game", "data-science", "data-analyst", "database", "embedded", "cyber-security", "blockchain", "system", "networking", "hardware", "sap-abap"]`
+  `["mobile", "backend", "frontend", "devops", "pm", "qa", "game", "data-science", "data-analyst", "database", "embedded", "cyber-security", "blockchain", "system", "networking", "hardware", "sap-abap"]`
   
 - **Staj Yeri** için şu seçeneklerden biri belirtilmelidir:  
   `["uzaktan", "yüzyüze"]`


### PR DESCRIPTION
This pull request adds support for the "devops" field in both the project labels and the README documentation. This ensures that students and contributors can now specify "devops" as an area of expertise or interest.

Label and documentation updates:

* [`.github/labels.json`](diffhunk://#diff-e2fc5abdfc47896652566c565d68af637e56e947a154572f33f7491bcbfaccbaR6): Added "devops" to the list of available labels for categorizing issues and pull requests.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the list of accepted fields in the "Alan" section to include "devops", so students can indicate this area when introducing themselves.