### PR TITLE
Fix: Resolve statistics fragmentation and empty weekly summaries

### DIFF
--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -49,12 +49,17 @@ def parse_issue_title(title):
         return None
     
     name, category, location, intern_type, duration = match.groups()
+
+    def clean_and_split(text):
+        cleaned_text = text.replace('[', '').replace(']', '')
+        return [item.strip() for item in cleaned_text.split(',')] if cleaned_text else []
+
     return {
         "name": name.strip(),
-        "category": [c.strip() for c in category.split(",")],
-        "location": [l.strip() for l in location.split(",")],
-        "intern_type": intern_type.strip(),
-        "duration": [d.strip() for d in duration.split(",")]
+        "category": [c for c in clean_and_split(category) if c],
+        "location": [l for l in clean_and_split(location) if l],
+        "intern_type": [it for it in clean_and_split(intern_type) if it],
+        "duration": [d for d in clean_and_split(duration) if d]
     }
 
 def fetch_all_issues():
@@ -127,7 +132,8 @@ def calculate_statistics(issues):
             stats["locations"][loc] += 1
         
         # Staj tipi
-        stats["intern_types"][parsed["intern_type"]] += 1
+        for itype in parsed["intern_type"]:
+            stats["intern_types"][itype] += 1
         
         # Süreler
         for dur in parsed["duration"]:

--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -51,15 +51,14 @@ def parse_issue_title(title):
     name, category, location, intern_type, duration = match.groups()
 
     def clean_and_split(text):
-        cleaned_text = text.replace('[', '').replace(']', '')
-        return [item.strip() for item in cleaned_text.split(',')] if cleaned_text else []
+        return [item.strip() for item in text.replace('[', '').replace(']', '').split(',') if item.strip()]
 
     return {
         "name": name.strip(),
-        "category": [c for c in clean_and_split(category) if c],
-        "location": [l for l in clean_and_split(location) if l],
-        "intern_type": [it for it in clean_and_split(intern_type) if it],
-        "duration": [d for d in clean_and_split(duration) if d]
+        "category": clean_and_split(category),
+        "location": clean_and_split(location),
+        "intern_type": clean_and_split(intern_type),
+        "duration": clean_and_split(duration)
     }
 
 def fetch_all_issues():

--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -51,19 +51,18 @@ def parse_issue_title(title):
     name, category, location, intern_type, duration = match.groups()
 
     def clean_and_split(text):
-        cleaned_text = text.replace('[', '').replace(']', '')
-        return [item.strip() for item in cleaned_text.split(',')] if cleaned_text else []
+        return [item.strip() for item in text.replace('[', '').replace(']', '').split(',') if item.strip()]
 
     return {
         "name": name.strip(),
-        "category": [c for c in clean_and_split(category) if c],
-        "location": [l for l in clean_and_split(location) if l],
-        "intern_type": [it for it in clean_and_split(intern_type) if it],
-        "duration": [d for d in clean_and_split(duration) if d]
+        "category": clean_and_split(category),
+        "location": clean_and_split(location),
+        "intern_type": clean_and_split(intern_type),
+        "duration": clean_and_split(duration)
     }
 
-def fetch_issues_since(since_date):
-    """Belirli bir tarihten sonraki issue'ları çeker"""
+def fetch_issues_since(since_date, until_date=None):
+    """Belirli bir tarih aralığındaki issue'ları çeker"""
     all_issues = []
     page = 1
     per_page = 100
@@ -94,6 +93,8 @@ def fetch_issues_since(since_date):
             filtered_issues = []
             for issue in issues:
                 created_at = datetime.strptime(issue["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+                if until_date and created_at >= until_date:
+                    continue  # Üst sınırı aşanları atla
                 if created_at >= since_date:
                     filtered_issues.append(issue)
                 else:
@@ -255,11 +256,11 @@ def main():
         week_start = today - timedelta(days=days_since_monday)
 
     week_start = week_start.replace(hour=0, minute=0, second=0, microsecond=0)
-    week_end = datetime.now()
+    week_end = today.replace(hour=0, minute=0, second=0, microsecond=0)
     
     print(f"Haftalık özet oluşturuluyor: {week_start.strftime('%d.%m.%Y')} - {week_end.strftime('%d.%m.%Y')}")
     
-    issues = fetch_issues_since(week_start)
+    issues = fetch_issues_since(week_start, week_end)
     print(f"Bu hafta {len(issues)} yeni başvuru bulundu")
     
     stats = calculate_weekly_stats(issues)

--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -49,12 +49,17 @@ def parse_issue_title(title):
         return None
     
     name, category, location, intern_type, duration = match.groups()
+
+    def clean_and_split(text):
+        cleaned_text = text.replace('[', '').replace(']', '')
+        return [item.strip() for item in cleaned_text.split(',')] if cleaned_text else []
+
     return {
         "name": name.strip(),
-        "category": [c.strip() for c in category.split(",")],
-        "location": [l.strip() for l in location.split(",")],
-        "intern_type": intern_type.strip(),
-        "duration": [d.strip() for d in duration.split(",")]
+        "category": [c for c in clean_and_split(category) if c],
+        "location": [l for l in clean_and_split(location) if l],
+        "intern_type": [it for it in clean_and_split(intern_type) if it],
+        "duration": [d for d in clean_and_split(duration) if d]
     }
 
 def fetch_issues_since(since_date):
@@ -135,7 +140,8 @@ def calculate_weekly_stats(issues):
         for loc in parsed["location"]:
             stats["locations"][loc] += 1
         
-        stats["intern_types"][parsed["intern_type"]] += 1
+        for itype in parsed["intern_type"]:
+            stats["intern_types"][itype] += 1
         
         for dur in parsed["duration"]:
             stats["durations"][dur] += 1
@@ -238,9 +244,16 @@ def create_discussion(title, body):
 
 def main():
     # Bu haftanın başlangıcı (Pazartesi)
+    # Bugün Pazartesi ise, geçen haftanın özetini çıkarmak için 7 gün geriye git.
+    # Pazartesi değilse, bu haftanın Pazartesisinden başla.
     today = datetime.now()
     days_since_monday = today.weekday()
-    week_start = today - timedelta(days=days_since_monday)
+
+    if days_since_monday == 0:
+        week_start = today - timedelta(days=7)
+    else:
+        week_start = today - timedelta(days=days_since_monday)
+
     week_start = week_start.replace(hour=0, minute=0, second=0, microsecond=0)
     week_end = datetime.now()
     


### PR DESCRIPTION
This PR addresses two main bugs impacting the accuracy of the repository's data processing and automated weekly summaries:
1. Irregularly formatted brackets and comma-separated values in issue titles were fracturing the generated statistics.
2. The automated weekly summary was rendering empty issues due to a flawed local date calculation.

### Changes
* **Improved Parsing Strategy (`generate_stats.py` & `weekly_summary.py`):** Refactored the `parse_issue_title()` function to properly remove lingering bracket artifacts and correctly iterate through comma-separated strings. This resolves the fragmented category issue (e.g. tracking `[zorunlu,gönüllü]` as separate increments rather than a literal merged string).
* **Weekly Summary Date Range Fix:** Corrected the timedelta logic in `weekly_summary.py`. When the script is triggered on a Monday by GitHub Actions, it will now correctly fetch the preceding 7 days (last week's interval) instead of defaulting to a 0-day difference, which caused empty reports.

<img width="1849" height="309" alt="1" src="https://github.com/user-attachments/assets/b38f9fef-0d97-4c33-af91-df2ac4bd31b3" />
<img width="954" height="597" alt="2" src="https://github.com/user-attachments/assets/30d6b43a-8220-4fba-9da5-2945c3d461b9" />